### PR TITLE
feat(numbers,identifiers): add support for floats, hex, oct, bin numbers

### DIFF
--- a/src/lang/arithmitic/index.test.js
+++ b/src/lang/arithmitic/index.test.js
@@ -1,5 +1,3 @@
-import {other_token} from '@fink/prattler/symbols';
-
 import {parse_expr} from '../../';
 
 

--- a/src/lang/arithmitic/index.test.js.snap
+++ b/src/lang/arithmitic/index.test.js.snap
@@ -4,46 +4,46 @@ exports[`arithmitic parses grouped: (a - b) * c 1`] = `
 arithm * (1:0-1:11)
   group (1:0-1:7)
     arithm - (1:1-1:6)
-      other (1:1-1:2) a
-      other (1:5-1:6) b
-  other (1:10-1:11) c
+      ident (1:1-1:2) a
+      ident (1:5-1:6) b
+  ident (1:10-1:11) c
 `;
 
 exports[`arithmitic parses single line: a % b / c 1`] = `
 arithm / (1:0-1:9)
   arithm % (1:0-1:5)
-    other (1:0-1:1) a
-    other (1:4-1:5) b
-  other (1:8-1:9) c
+    ident (1:0-1:1) a
+    ident (1:4-1:5) b
+  ident (1:8-1:9) c
 `;
 
 exports[`arithmitic parses single line: a * -b 1`] = `
 arithm * (1:0-1:6)
-  other (1:0-1:1) a
+  ident (1:0-1:1) a
   arithm_prefix - (1:4-1:6)
-    other (1:5-1:6) b
+    ident (1:5-1:6) b
 `;
 
 exports[`arithmitic parses single line: a * b + c 1`] = `
 arithm + (1:0-1:9)
   arithm * (1:0-1:5)
-    other (1:0-1:1) a
-    other (1:4-1:5) b
-  other (1:8-1:9) c
+    ident (1:0-1:1) a
+    ident (1:4-1:5) b
+  ident (1:8-1:9) c
 `;
 
 exports[`arithmitic parses single line: a + b * c 1`] = `
 arithm + (1:0-1:9)
-  other (1:0-1:1) a
+  ident (1:0-1:1) a
   arithm * (1:4-1:9)
-    other (1:4-1:5) b
-    other (1:8-1:9) c
+    ident (1:4-1:5) b
+    ident (1:8-1:9) c
 `;
 
 exports[`arithmitic parses single line: a ^ b * c 1`] = `
 arithm * (1:0-1:9)
   arithm_right ^ (1:0-1:5)
-    other (1:0-1:1) a
-    other (1:4-1:5) b
-  other (1:8-1:9) c
+    ident (1:0-1:1) a
+    ident (1:4-1:5) b
+  ident (1:8-1:9) c
 `;

--- a/src/lang/assignment/index.test.js
+++ b/src/lang/assignment/index.test.js
@@ -1,7 +1,4 @@
-import {other_token} from '@fink/prattler/symbols';
-
 import {parse_expr} from '../../';
-import {strip_block} from '../../string-utils';
 
 
 describe('assignment', ()=> {

--- a/src/lang/assignment/index.test.js.snap
+++ b/src/lang/assignment/index.test.js.snap
@@ -2,6 +2,6 @@
 
 exports[`assignment parses single line: foo = bar 1`] = `
 assign = (1:0-1:9)
-  other (1:0-1:3) foo
-  other (1:6-1:9) bar
+  ident (1:0-1:3) foo
+  ident (1:6-1:9) bar
 `;

--- a/src/lang/async/index.test.js
+++ b/src/lang/async/index.test.js
@@ -1,5 +1,3 @@
-import {other_token} from '@fink/prattler/symbols';
-
 import {parse_expr} from '../../';
 
 

--- a/src/lang/async/index.test.js.snap
+++ b/src/lang/async/index.test.js.snap
@@ -2,5 +2,5 @@
 
 exports[`assignment parses single line: foo = bar 1`] = `
 await (1:0-1:12)
-  other (1:6-1:12) foobar
+  ident (1:6-1:12) foobar
 `;

--- a/src/lang/call/call.test.js
+++ b/src/lang/call/call.test.js
@@ -1,8 +1,4 @@
-import {other_token} from '@fink/prattler/symbols';
-
 import {parse_expr} from '../..';
-
-
 import {strip_block} from '../../string-utils';
 
 

--- a/src/lang/call/call.test.js.snap
+++ b/src/lang/call/call.test.js.snap
@@ -2,48 +2,48 @@
 
 exports[`call() parses dangling comma: foobar(1, 2,) 1`] = `
 call (1:0-1:13)
-  other (1:0-1:6) foobar
-  other (1:7-1:8) 1
-  other (1:10-1:11) 2
+  ident (1:0-1:6) foobar
+  number (1:7-1:8) 1
+  number (1:10-1:11) 2
 
 `;
 
 exports[`call() parses empty: foobar() 1`] = `
 call (1:0-1:8)
-  other (1:0-1:6) foobar
+  ident (1:0-1:6) foobar
 
 `;
 
 exports[`call() parses multiple args: foobar(1, 2) 1`] = `
 call (1:0-1:12)
-  other (1:0-1:6) foobar
-  other (1:7-1:8) 1
-  other (1:10-1:11) 2
+  ident (1:0-1:6) foobar
+  number (1:7-1:8) 1
+  number (1:10-1:11) 2
 
 `;
 
 exports[`call() parses single arg: foobar(1) 1`] = `
 call (1:0-1:9)
-  other (1:0-1:6) foobar
-  other (1:7-1:8) 1
+  ident (1:0-1:6) foobar
+  number (1:7-1:8) 1
 
 `;
 
 exports[`call:: ... parses args: foobar:: spam, ni 1`] = `
 call (1:0-1:15)
-  other (1:0-1:6) foobar
-  other (1:9-1:13) spam
-  other (1:15-1:17) ni
+  ident (1:0-1:6) foobar
+  ident (1:9-1:13) spam
+  ident (1:15-1:17) ni
 
 `;
 
 exports[`pipe foo: ... pipes 1`] = `
 block pipe (1:0-3:4)
-  other (1:5-1:8) foo
+  ident (1:5-1:8) foo
   :
   call (2:2-2:12)
-    other (2:2-2:5) bar
-    other (2:6-2:11) shrub
+    ident (2:2-2:5) bar
+    ident (2:6-2:11) shrub
 
-  other (3:2-3:4) ni
+  ident (3:2-3:4) ni
 `;

--- a/src/lang/comments/index.test.js.snap
+++ b/src/lang/comments/index.test.js.snap
@@ -2,12 +2,12 @@
 
 exports[`comments parses doc-comment 1`] = `
 assign = (4:0-4:9)
-  other (4:0-4:4) spam
-  other (4:7-4:9) ni
+  ident (4:0-4:4) spam
+  ident (4:7-4:9) ni
 `;
 
 exports[`comments parses line comment 1`] = `
 assign = (2:0-2:9)
-  other (2:0-2:4) spam
-  other (2:7-2:9) ni
+  ident (2:0-2:4) spam
+  ident (2:7-2:9) ni
 `;

--- a/src/lang/comparison/index.test.js
+++ b/src/lang/comparison/index.test.js
@@ -1,5 +1,3 @@
-import {other_token} from '@fink/prattler/symbols';
-
 import {parse_expr} from '../../';
 
 

--- a/src/lang/comparison/index.test.js.snap
+++ b/src/lang/comparison/index.test.js.snap
@@ -2,36 +2,36 @@
 
 exports[`comparison parses single line: a != b 1`] = `
 comp != (1:0-1:6)
-  other (1:0-1:1) a
-  other (1:5-1:6) b
+  ident (1:0-1:1) a
+  ident (1:5-1:6) b
 `;
 
 exports[`comparison parses single line: a < b 1`] = `
 comp < (1:0-1:5)
-  other (1:0-1:1) a
-  other (1:4-1:5) b
+  ident (1:0-1:1) a
+  ident (1:4-1:5) b
 `;
 
 exports[`comparison parses single line: a <= b 1`] = `
 comp <= (1:0-1:6)
-  other (1:0-1:1) a
-  other (1:5-1:6) b
+  ident (1:0-1:1) a
+  ident (1:5-1:6) b
 `;
 
 exports[`comparison parses single line: a == b 1`] = `
 comp == (1:0-1:6)
-  other (1:0-1:1) a
-  other (1:5-1:6) b
+  ident (1:0-1:1) a
+  ident (1:5-1:6) b
 `;
 
 exports[`comparison parses single line: a > b 1`] = `
 comp > (1:0-1:5)
-  other (1:0-1:1) a
-  other (1:4-1:5) b
+  ident (1:0-1:1) a
+  ident (1:4-1:5) b
 `;
 
 exports[`comparison parses single line: a >= b 1`] = `
 comp >= (1:0-1:6)
-  other (1:0-1:1) a
-  other (1:5-1:6) b
+  ident (1:0-1:1) a
+  ident (1:5-1:6) b
 `;

--- a/src/lang/conditionals/index.test.js
+++ b/src/lang/conditionals/index.test.js
@@ -1,8 +1,4 @@
-import {other_token} from '@fink/prattler/symbols';
-
 import {parse_expr} from '../../';
-
-
 import {strip_block} from '../../string-utils';
 
 

--- a/src/lang/conditionals/index.test.js.snap
+++ b/src/lang/conditionals/index.test.js.snap
@@ -2,14 +2,14 @@
 
 exports[`match ...: parses single line: match foo: bar 1`] = `
 cond match (1:0-3:12)
-  other (1:6-1:10) item
+  ident (1:6-1:10) item
   :
   cond:test:result (2:2-2:10)
-    other (2:2-2:5) foo
+    ident (2:2-2:5) foo
     block (2:5-2:10)
-      other (2:7-2:10) bar
+      ident (2:7-2:10) bar
   cond:test:result (3:2-3:12)
-    other (3:2-3:6) else
+    ident (3:2-3:6) else
     block (3:6-3:12)
-      other (3:8-3:12) spam
+      ident (3:8-3:12) spam
 `;

--- a/src/lang/func/index.test.js.snap
+++ b/src/lang/func/index.test.js.snap
@@ -2,17 +2,17 @@
 
 exports[`func: fn ...: ... parses multi line: fn foo, bar: foo 1`] = `
 block fn (1:0-3:5)
-  other (1:3-1:6) foo
-  other (1:8-1:11) bar
+  ident (1:3-1:6) foo
+  ident (1:8-1:11) bar
   :
-  other (2:2-2:5) foo
-  other (3:2-3:5) bar
+  ident (2:2-2:5) foo
+  ident (3:2-3:5) bar
 `;
 
 exports[`func: fn ...: ... parses single line: fn foo, bar: foo 1`] = `
 block fn (1:0-1:16)
-  other (1:3-1:6) foo
-  other (1:8-1:11) bar
+  ident (1:3-1:6) foo
+  ident (1:8-1:11) bar
   :
-  other (1:13-1:16) foo
+  ident (1:13-1:16) foo
 `;

--- a/src/lang/group/index.test.js
+++ b/src/lang/group/index.test.js
@@ -1,8 +1,4 @@
-import {other_token} from '@fink/prattler/symbols';
-
 import {parse_expr} from '../..';
-
-
 import {strip_block} from '../../string-utils';
 
 

--- a/src/lang/group/index.test.js.snap
+++ b/src/lang/group/index.test.js.snap
@@ -2,6 +2,6 @@
 
 exports[`group: (...) parses single line: (foo, bar) 1`] = `
 group (1:0-1:10)
-  other (1:1-1:4) foo
-  other (1:6-1:9) bar
+  ident (1:1-1:4) foo
+  ident (1:6-1:9) bar
 `;

--- a/src/lang/identifier/other.js
+++ b/src/lang/identifier/other.js
@@ -63,7 +63,6 @@ const number = (ctx)=> {
 export const other = ()=> ({
   ...symbol(other_token),
 
-  // eslint-disable-next-line max-statements
   nud: ()=> (ctx)=> {
     const value = curr_value(ctx);
     const loc = curr_loc(ctx);

--- a/src/lang/identifier/other.js
+++ b/src/lang/identifier/other.js
@@ -1,6 +1,8 @@
 import {
-  curr_value, curr_loc, expression, next_matches, next_loc
+  curr_value, curr_loc, expression, next_matches, next_loc, next_is,
+  assert_advance, advance
 } from '@fink/prattler';
+import {token_error} from '@fink/prattler/errors';
 import {other_token, next_lbp} from '@fink/prattler/symbols';
 
 import {symbol} from '../symbols';
@@ -20,15 +22,57 @@ const infix_led = (lbp)=> (ctx, left)=> {
 };
 
 
+const looks_like_num = (ctx)=> {
+  const value = curr_value(ctx);
+  return value.match(/^[0-9]+.*/) !== null;
+};
+
+
+// eslint-disable-next-line max-statements
+const number = (ctx)=> {
+  let value = curr_value(ctx);
+  const {start} = curr_loc(ctx);
+
+  if (next_is(ctx, '.')) {
+    ctx = advance(ctx);
+    value += curr_value(ctx);
+    ctx = advance(ctx);
+    value += curr_value(ctx);
+
+    if (value.endsWith('e')) {
+      ctx = advance(ctx);
+      value += curr_value(ctx);
+
+      if (curr_value(ctx) === '+' || curr_value(ctx) === '-') {
+        ctx = advance(ctx);
+        value += curr_value(ctx);
+      } else {
+        throw token_error(
+          `Expected exponent:`,
+          ctx.curr_token, ctx
+        );
+      }
+    }
+  }
+
+  const {end} = curr_loc(ctx);
+  return [{type: 'number', value, loc: {start, end}}, ctx];
+};
+
+
 export const other = ()=> ({
   ...symbol(other_token),
 
+  // eslint-disable-next-line max-statements
   nud: ()=> (ctx)=> {
     const value = curr_value(ctx);
     const loc = curr_loc(ctx);
 
-    // TODO: use 'other' instead of other_token
-    return [{type: other_token, value, loc}, ctx];
+    if (looks_like_num(ctx)) {
+      return number(ctx);
+    }
+
+    return [{type: 'ident', value, loc}, ctx];
   },
 
   led: (lbp)=> infix_led(lbp-1)

--- a/src/lang/identifier/other.test.js
+++ b/src/lang/identifier/other.test.js
@@ -1,8 +1,4 @@
-import {other_token} from '@fink/prattler/symbols';
-
 import {parse_expr, parse} from '../../';
-
-
 import {strip_block} from '../../string-utils';
 
 

--- a/src/lang/identifier/other.test.js
+++ b/src/lang/identifier/other.test.js
@@ -1,6 +1,6 @@
 import {other_token} from '@fink/prattler/symbols';
 
-import {parse_expr} from '../../';
+import {parse_expr, parse} from '../../';
 
 
 import {strip_block} from '../../string-utils';
@@ -22,10 +22,59 @@ describe('other symbols', ()=> {
 });
 
 
-describe('symbols as infix operators', ()=> {
-  it('parses a word', ()=> {
+describe('numbers', ()=> {
+  it('parses int 12345', ()=> {
     expect(
-      parse_expr(`123 add 2`)
+      parse_expr(` 12345  `)
+    ).toMatchSnapshot();
+  });
+
+
+  it('parses hex, oct, bin', ()=> {
+    expect(
+      parse(strip_block`
+        0x123456789abcdef0
+        0x123456789abcde
+        0o12345670
+        0b101010
+      `)
+    ).toMatchSnapshot();
+  });
+
+
+  it('parses float 123.456', ()=> {
+    expect(
+      parse_expr(`  123.456  `)
+    ).toMatchSnapshot();
+  });
+
+
+  it('parses float 123.456e10', ()=> {
+    expect(
+      parse(strip_block`
+        123.456e78
+        123.456e+78
+        123.456e-78
+      `)
+    ).toMatchSnapshot();
+  });
+
+  it('throws when missing exponent', ()=> {
+    expect(
+      ()=> parse_expr(`123.456e * 78`)
+    ).toThrow(strip_block`
+      Expected exponent:
+      1| 123.456e * 78
+                  ^`
+    );
+  });
+});
+
+
+describe('symbols as infix operators', ()=> {
+  it('parses with left to right precendence', ()=> {
+    expect(
+      parse_expr(`123 add 4 add 5`)
     ).toMatchSnapshot();
   });
 });

--- a/src/lang/identifier/other.test.js.snap
+++ b/src/lang/identifier/other.test.js.snap
@@ -1,11 +1,32 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`other symbols parses a non-word 1`] = `other (1:2-1:3) π`;
+exports[`numbers parses float 123.456 1`] = `number (1:2-1:9) 123.456`;
 
-exports[`other symbols parses a word 1`] = `other (1:2-1:8) foobar`;
+exports[`numbers parses float 123.456e10 1`] = `
+module (1:0-3:11)
+  number (1:0-1:10) 123.456e78
+  number (2:0-2:11) 123.456e+78
+  number (3:0-3:11) 123.456e-78
+`;
 
-exports[`symbols as infix operators parses a word 1`] = `
-infix add (1:0-1:9)
-  other (1:0-1:3) 123
-  other (1:8-1:9) 2
+exports[`numbers parses hex, oct, bin 1`] = `
+module (1:0-4:8)
+  number (1:0-1:18) 0x123456789abcdef0
+  number (2:0-2:16) 0x123456789abcde
+  number (3:0-3:10) 0o12345670
+  number (4:0-4:8) 0b101010
+`;
+
+exports[`numbers parses int 12345 1`] = `number (1:1-1:6) 12345`;
+
+exports[`other symbols parses a non-word 1`] = `ident (1:2-1:3) π`;
+
+exports[`other symbols parses a word 1`] = `ident (1:2-1:8) foobar`;
+
+exports[`symbols as infix operators parses with left to right precendence 1`] = `
+infix add (1:0-1:15)
+  infix add (1:0-1:9)
+    number (1:0-1:3) 123
+    number (1:8-1:9) 4
+  number (1:14-1:15) 5
 `;

--- a/src/lang/iterable/index.test.js
+++ b/src/lang/iterable/index.test.js
@@ -1,5 +1,3 @@
-import {other_token} from '@fink/prattler/symbols';
-
 import {parse_expr} from '../../';
 import {strip_block} from '../../string-utils';
 

--- a/src/lang/iterable/index.test.js.snap
+++ b/src/lang/iterable/index.test.js.snap
@@ -2,61 +2,61 @@
 
 exports[`filter item: ... parses 1`] = `
 block filter (1:0-2:15)
-  other (1:7-1:11) item
+  ident (1:7-1:11) item
   :
   comp == (2:2-2:15)
     arithm % (2:2-2:10)
-      other (2:2-2:6) item
-      other (2:9-2:10) 2
-    other (2:14-2:15) 0
+      ident (2:2-2:6) item
+      number (2:9-2:10) 2
+    number (2:14-2:15) 0
 `;
 
 exports[`flat_map item: ... parses 1`] = `
 block flat_map (1:0-2:18)
-  other (1:9-1:13) item
+  ident (1:9-1:13) item
   :
   array (2:2-2:18)
-    other (2:3-2:7) item
+    ident (2:3-2:7) item
     arithm * (2:9-2:17)
-      other (2:9-2:13) item
-      other (2:16-2:17) 2
+      ident (2:9-2:13) item
+      number (2:16-2:17) 2
 `;
 
 exports[`fold item, accu: ... parses 1`] = `
 block fold (1:0-2:13)
-  other (1:5-1:9) item
+  ident (1:5-1:9) item
   assign = (1:11-1:17)
-    other (1:11-1:15) accu
-    other (1:16-1:17) 0
+    ident (1:11-1:15) accu
+    number (1:16-1:17) 0
   :
   arithm + (2:2-2:13)
-    other (2:2-2:6) item
-    other (2:9-2:13) accu
+    ident (2:2-2:6) item
+    ident (2:9-2:13) accu
 `;
 
 exports[`map item: ... parses 1`] = `
 block map (1:0-2:10)
-  other (1:4-1:8) item
+  ident (1:4-1:8) item
   :
   arithm * (2:2-2:10)
-    other (2:2-2:6) item
-    other (2:9-2:10) 2
+    ident (2:2-2:6) item
+    number (2:9-2:10) 2
 `;
 
 exports[`unfold item, accu: ... parses 1`] = `
 block unfold (1:0-2:26)
   assign = (1:7-1:17)
-    other (1:7-1:11) curr
-    other (1:12-1:17) start
+    ident (1:7-1:11) curr
+    ident (1:12-1:17) start
   assign = (1:19-1:25)
-    other (1:19-1:23) accu
-    other (1:24-1:25) 0
+    ident (1:19-1:23) accu
+    number (1:24-1:25) 0
   :
   group (2:2-2:26)
     arithm + (2:3-2:15)
-      other (2:3-2:8) start
-      other (2:11-2:15) accu
+      ident (2:3-2:8) start
+      ident (2:11-2:15) accu
     arithm + (2:17-2:25)
-      other (2:17-2:21) accu
-      other (2:24-2:25) 1
+      ident (2:17-2:21) accu
+      number (2:24-2:25) 1
 `;

--- a/src/lang/jsx/index.test.js.snap
+++ b/src/lang/jsx/index.test.js.snap
@@ -20,8 +20,8 @@ jsx-elem (1:0-3:9) Foobar
   jsx-expr-container (2:2-2:8)
     block (2:2-2:8)
       arithm + (2:3-2:8)
-        other (2:3-2:4) 1
-        other (2:7-2:8) 2
+        number (2:3-2:4) 1
+        number (2:7-2:8) 2
   jsx-text (2:8-2:9)
     "\\n"
 `;
@@ -33,7 +33,7 @@ jsx-elem (1:0-1:20) Foobar
   jsx-attr (1:8-1:17) spam
         jsx-expr-container (1:13-1:16)
       block (1:13-1:16)
-        other (1:14-1:16) ni
+        ident (1:14-1:16) ni
 `;
 
 exports[`JSX <Foobar>...</Foobar> parses self closing elem with short attr: <Foobar spam /> 1`] = `

--- a/src/lang/literals/array.test.js
+++ b/src/lang/literals/array.test.js
@@ -1,8 +1,4 @@
-import {other_token} from '@fink/prattler/symbols';
-
 import {parse_expr} from '../../';
-
-
 import {strip_block} from '../../string-utils';
 
 

--- a/src/lang/literals/array.test.js.snap
+++ b/src/lang/literals/array.test.js.snap
@@ -2,8 +2,8 @@
 
 exports[`array [...] parses dangling comma: [1, 2,] 1`] = `
 array (1:0-1:7)
-  other (1:1-1:2) 1
-  other (1:4-1:5) 2
+  number (1:1-1:2) 1
+  number (1:4-1:5) 2
 `;
 
 exports[`array [...] parses empty: [] 1`] = `
@@ -15,16 +15,16 @@ exports[`array [...] parses leading commas: [,, foo] 1`] = `
 array (1:0-1:8)
 
 
-  other (1:4-1:7) foo
+  ident (1:4-1:7) foo
 `;
 
 exports[`array [...] parses multiple elements: [1, 2] 1`] = `
 array (1:0-1:6)
-  other (1:1-1:2) 1
-  other (1:4-1:5) 2
+  number (1:1-1:2) 1
+  number (1:4-1:5) 2
 `;
 
 exports[`array [...] parses single elemement: [1] 1`] = `
 array (1:0-1:3)
-  other (1:1-1:2) 1
+  number (1:1-1:2) 1
 `;

--- a/src/lang/literals/object.js
+++ b/src/lang/literals/object.js
@@ -5,7 +5,6 @@ import {
 
 import {symbol} from '../symbols';
 import {seq} from '../generic/sequence';
-import {other_token} from '@fink/prattler/symbols';
 
 
 const value_expr = (ctx, key)=> {
@@ -38,7 +37,7 @@ const key_expr = (ctx)=> {
 
   const key_ctx = advance(ctx);
   const loc = curr_loc(key_ctx);
-  const key = {type: other_token, value: curr_value(key_ctx), loc};
+  const key = {type: 'ident', value: curr_value(key_ctx), loc};
 
   if (next_is(key_ctx, '=')) {
     return default_assignment(key_ctx, key);

--- a/src/lang/literals/object.test.js
+++ b/src/lang/literals/object.test.js
@@ -1,8 +1,4 @@
-import {other_token} from '@fink/prattler/symbols';
-
 import {parse_expr} from '../../';
-
-
 import {strip_block} from '../../string-utils';
 
 

--- a/src/lang/literals/object.test.js.snap
+++ b/src/lang/literals/object.test.js.snap
@@ -6,7 +6,7 @@ object (1:0-1:9)
     other (1:1-1:4) foo
     assign = (1:1-1:8)
       other (1:1-1:4) foo
-      other (1:5-1:8) 123
+      number (1:5-1:8) 123
 `;
 
 exports[`object {...} parses empty: {} 1`] = `
@@ -29,7 +29,7 @@ object (1:0-1:11)
   prop (1:1-1:10)
     other (1:1-1:4) foo
     block (1:4-1:10)
-      other (1:6-1:10) spam
+      ident (1:6-1:10) spam
 `;
 
 exports[`object {...} parses single shorthand prop: {foo} 1`] = `
@@ -45,5 +45,5 @@ object (1:0-1:13)
     string \` (1:1-1:6)
       \`foo\`
     block (1:6-1:12)
-      other (1:8-1:12) spam
+      ident (1:8-1:12) spam
 `;

--- a/src/lang/literals/object.test.js.snap
+++ b/src/lang/literals/object.test.js.snap
@@ -3,9 +3,9 @@
 exports[`object {...} parses default assignment prop: {foo=123} 1`] = `
 object (1:0-1:9)
   prop (1:1-1:8)
-    other (1:1-1:4) foo
+    ident (1:1-1:4) foo
     assign = (1:1-1:8)
-      other (1:1-1:4) foo
+      ident (1:1-1:4) foo
       number (1:5-1:8) 123
 `;
 
@@ -17,17 +17,17 @@ object (1:0-1:2)
 exports[`object {...} parses multiple shorthand exprs: {foo, bar} 1`] = `
 object (1:0-1:10)
   prop (1:1-1:4)
-    other (1:1-1:4) foo
-    other (1:1-1:4) foo
+    ident (1:1-1:4) foo
+    ident (1:1-1:4) foo
   prop (1:6-1:9)
-    other (1:6-1:9) bar
-    other (1:6-1:9) bar
+    ident (1:6-1:9) bar
+    ident (1:6-1:9) bar
 `;
 
 exports[`object {...} parses single prop: {foo: spam} 1`] = `
 object (1:0-1:11)
   prop (1:1-1:10)
-    other (1:1-1:4) foo
+    ident (1:1-1:4) foo
     block (1:4-1:10)
       ident (1:6-1:10) spam
 `;
@@ -35,8 +35,8 @@ object (1:0-1:11)
 exports[`object {...} parses single shorthand prop: {foo} 1`] = `
 object (1:0-1:5)
   prop (1:1-1:4)
-    other (1:1-1:4) foo
-    other (1:1-1:4) foo
+    ident (1:1-1:4) foo
+    ident (1:1-1:4) foo
 `;
 
 exports[`object {...} parses single str prop: {\`foo\`: spam} 1`] = `

--- a/src/lang/literals/regex.test.js
+++ b/src/lang/literals/regex.test.js
@@ -1,8 +1,4 @@
-import {other_token} from '@fink/prattler/symbols';
-
 import {parse_expr} from '../../';
-
-
 import {strip_block} from '../../string-utils';
 
 

--- a/src/lang/literals/string.test.js
+++ b/src/lang/literals/string.test.js
@@ -1,8 +1,4 @@
-import {other_token} from '@fink/prattler/symbols';
-
 import {parse_expr} from '../../';
-
-
 import {strip_block} from '../../string-utils';
 
 

--- a/src/lang/logical/index.test.js
+++ b/src/lang/logical/index.test.js
@@ -1,8 +1,4 @@
-import {other_token} from '@fink/prattler/symbols';
-
 import {parse_expr} from '../../';
-
-
 import {strip_block} from '../../string-utils';
 
 

--- a/src/lang/logical/index.test.js.snap
+++ b/src/lang/logical/index.test.js.snap
@@ -2,21 +2,21 @@
 
 exports[`logical parses single line: !a 1`] = `
 logical ! (1:0-1:2)
-  other (1:1-1:2) a
+  ident (1:1-1:2) a
 `;
 
 exports[`logical parses single line: a && b || c 1`] = `
 logical || (1:0-1:11)
   logical && (1:0-1:6)
-    other (1:0-1:1) a
-    other (1:5-1:6) b
-  other (1:10-1:11) c
+    ident (1:0-1:1) a
+    ident (1:5-1:6) b
+  ident (1:10-1:11) c
 `;
 
 exports[`logical parses single line: a || b && c 1`] = `
 logical || (1:0-1:11)
-  other (1:0-1:1) a
+  ident (1:0-1:1) a
   logical && (1:5-1:11)
-    other (1:5-1:6) b
-    other (1:10-1:11) c
+    ident (1:5-1:6) b
+    ident (1:10-1:11) c
 `;

--- a/src/lang/module/index.test.js.snap
+++ b/src/lang/module/index.test.js.snap
@@ -3,9 +3,9 @@
 exports[`module parses module 1`] = `
 module (1:0-2:9)
   assign = (1:0-1:9)
-    other (1:0-1:3) foo
-    other (1:6-1:9) bar
+    ident (1:0-1:3) foo
+    ident (1:6-1:9) bar
   assign = (2:0-2:9)
-    other (2:0-2:4) spam
-    other (2:7-2:9) ni
+    ident (2:0-2:4) spam
+    ident (2:7-2:9) ni
 `;

--- a/src/lang/prop-access/index.js
+++ b/src/lang/prop-access/index.js
@@ -1,7 +1,7 @@
 import {
   advance, curr_loc, curr_value, next_is, expression
 } from '@fink/prattler';
-import {add_operator_like, other_token} from '@fink/prattler/symbols';
+import {add_operator_like} from '@fink/prattler/symbols';
 import {symbol} from '../symbols';
 
 
@@ -13,7 +13,7 @@ const member_expr = (ctx, lbp)=> {
   const key_ctx = advance(ctx);
   const loc = curr_loc(key_ctx);
 
-  return [{type: other_token, value: curr_value(key_ctx), loc}, key_ctx];
+  return [{type: 'ident', value: curr_value(key_ctx), loc}, key_ctx];
 };
 
 

--- a/src/lang/prop-access/index.test.js
+++ b/src/lang/prop-access/index.test.js
@@ -1,5 +1,3 @@
-import {other_token} from '@fink/prattler/symbols';
-
 import {parse_expr} from '../../';
 
 

--- a/src/lang/prop-access/index.test.js.snap
+++ b/src/lang/prop-access/index.test.js.snap
@@ -2,22 +2,22 @@
 
 exports[`prop access parses member expr: foo.(Symbol.iterator) 1`] = `
 member . (1:0-1:21)
-  other (1:0-1:3) foo
+  ident (1:0-1:3) foo
   group (1:4-1:21)
     member . (1:5-1:20)
-      other (1:5-1:11) Symbol
+      ident (1:5-1:11) Symbol
       other (1:12-1:20) iterator
 `;
 
 exports[`prop access parses member expr: foo.\`bar spam\` 1`] = `
 member . (1:0-1:14)
-  other (1:0-1:3) foo
+  ident (1:0-1:3) foo
   string \` (1:4-1:14)
     \`bar spam\`
 `;
 
 exports[`prop access parses single line: foo.bar 1`] = `
 member . (1:0-1:7)
-  other (1:0-1:3) foo
+  ident (1:0-1:3) foo
   other (1:4-1:7) bar
 `;

--- a/src/lang/prop-access/index.test.js.snap
+++ b/src/lang/prop-access/index.test.js.snap
@@ -6,7 +6,7 @@ member . (1:0-1:21)
   group (1:4-1:21)
     member . (1:5-1:20)
       ident (1:5-1:11) Symbol
-      other (1:12-1:20) iterator
+      ident (1:12-1:20) iterator
 `;
 
 exports[`prop access parses member expr: foo.\`bar spam\` 1`] = `
@@ -19,5 +19,5 @@ member . (1:0-1:14)
 exports[`prop access parses single line: foo.bar 1`] = `
 member . (1:0-1:7)
   ident (1:0-1:3) foo
-  other (1:4-1:7) bar
+  ident (1:4-1:7) bar
 `;

--- a/src/lang/spread/index.test.js
+++ b/src/lang/spread/index.test.js
@@ -1,5 +1,3 @@
-import {other_token} from '@fink/prattler/symbols';
-
 import {parse_expr} from '../../';
 
 

--- a/src/lang/spread/index.test.js.snap
+++ b/src/lang/spread/index.test.js.snap
@@ -2,5 +2,5 @@
 
 exports[`spread parses single line: ...foobar 1`] = `
 spread ... (1:0-1:9)
-  other (1:3-1:9) foobar
+  ident (1:3-1:9) foobar
 `;

--- a/src/lang/whitespace/index.test.js
+++ b/src/lang/whitespace/index.test.js
@@ -1,7 +1,5 @@
 import {init_parser, start_parser, next_is_end, next_loc} from '@fink/prattler';
-import {other_token} from '@fink/prattler/symbols';
 
-import {parse_expr} from '../../';
 import {init_language} from '..';
 
 

--- a/src/testing/serialize.js
+++ b/src/testing/serialize.js
@@ -1,15 +1,9 @@
-import {other_token} from '@fink/prattler/symbols';
 
-
-const str_type_op = ({type, op, loc: {start, end}})=> {
-  if (type === other_token) {
-    type = 'other';
-  }
-
-  return op && op !== type
+const str_type_op = ({type, op, loc: {start, end}})=> (
+  op && op !== type
     ? `${type} ${op} (${start.line}:${start.column}-${end.line}:${end.column})`
-    : `${type} (${start.line}:${start.column}-${end.line}:${end.column})`;
-};
+    : `${type} (${start.line}:${start.column}-${end.line}:${end.column})`
+);
 
 
 const serialize_block = (node, serialize, indent)=> {
@@ -131,7 +125,7 @@ export const serialize = (node, indent='')=> {
 
   const head = str_type_op(node);
 
-  if (node.type !== other_token && node.type.startsWith('jsx-')) {
+  if (node.type.startsWith('jsx-')) {
     return serialize_jsx(node, serialize, indent);
 
   } if (node.type === 'regex') {


### PR DESCRIPTION
BREAKING CHANGE: number nodes are of type `number` and all other tokens are treated as `ident` rather then `Symbol('other')`